### PR TITLE
151534487 ABAC: implement rules for Client county determination

### DIFF
--- a/api-core-abac/src/main/java/gov/ca/cwds/data/dao/cms/CountyDeterminationDao.java
+++ b/api-core-abac/src/main/java/gov/ca/cwds/data/dao/cms/CountyDeterminationDao.java
@@ -52,6 +52,19 @@ public class CountyDeterminationDao extends CrudsDaoImpl<CmsPersistentObject> {
 
   /**
    * @param clientId Client ID
+   * @return List of counties for Client by clientID from CLIENT_CNTY table
+   */
+  public List<Short> getClientCountyFromClientCountyTable(String clientId) {
+
+    String namedQuery = "SELECT GVR_ENTC\n"
+        + "  FROM CLIENT_CNTY A\n"
+        + "  WHERE A.CLIENT_ID = :clientId";
+
+    return executeNativeQueryAndReturnCountyList(namedQuery, clientId);
+  }
+
+  /**
+   * @param clientId Client ID
    * @return List of counties for Client by Active Cases with whom this Client is related
    */
   public List<Short> getClientCountyByActiveCase(String clientId) {

--- a/api-core-abac/src/main/java/gov/ca/cwds/service/ClientCountyDeterminationServiceImpl.java
+++ b/api-core-abac/src/main/java/gov/ca/cwds/service/ClientCountyDeterminationServiceImpl.java
@@ -31,6 +31,13 @@ public class ClientCountyDeterminationServiceImpl implements ClientCountyDetermi
   @Override
   public Short getClientCountyById(String clientId) {
 
+    //check CLIENT_CNTY table first
+    List<Short> countyFromClientCountyTableList = countyDeterminationDao
+        .getClientCountyFromClientCountyTable(clientId);
+    if (!countyFromClientCountyTableList.isEmpty()) {
+      return countyFromClientCountyTableList.get(0);
+    }
+
     //I. Active Case for the Client (only one active Case should exist for a Client via CHILD_CLIENT)
     List<Short> countyByActiveCaseList = countyDeterminationDao
         .getClientCountyByActiveCase(clientId);

--- a/api-core-abac/src/test/java/gov/ca/cwds/data/dao/cms/CountyDeterminationDaoTest.java
+++ b/api-core-abac/src/test/java/gov/ca/cwds/data/dao/cms/CountyDeterminationDaoTest.java
@@ -79,6 +79,9 @@ public class CountyDeterminationDaoTest {
     Whitebox.setInternalState(countyDeterminationDao, "sessionFactory",
         sessionFactory);
 
+    assertThat(countyDeterminationDao.getClientCountyFromClientCountyTable("testClientId").get(0),
+        is(equalTo((short) 11)));
+
     assertThat(countyDeterminationDao.getClientCountyByActiveCase("testClientId").get(0),
         is(equalTo((short) 11)));
 

--- a/api-core-abac/src/test/java/gov/ca/cwds/service/ClientCountyDeterminationServiceImplTest.java
+++ b/api-core-abac/src/test/java/gov/ca/cwds/service/ClientCountyDeterminationServiceImplTest.java
@@ -59,6 +59,18 @@ public class ClientCountyDeterminationServiceImplTest {
   }
 
   @Test
+  public void testGetClientCountyFromClientCountyTable() throws Exception {
+    final List<Short> list = new ArrayList<>();
+    list.add((short) 0);
+    doReturn(list).when(countyDeterminationDao).getClientCountyFromClientCountyTable(Mockito.anyString());
+    Whitebox.setInternalState(countyDeterminationService, "countyDeterminationDao",
+        countyDeterminationDao);
+
+    assertThat(countyDeterminationService.getClientCountyById("testClientId"),
+        is(equalTo((short) 0)));
+  }
+
+  @Test
   public void testGetClientByClientAnyActiveCase() throws Exception {
     final List<Short> list = new ArrayList<>();
     list.add((short) 1);


### PR DESCRIPTION
added mechanism for checking CLIENT_CNTY first when determining county of client;
added additional tests for Dao and ClientCountyDeterminationService;