### PR TITLE
generate(String staffId) method is removed, generate(String staffId, …

### DIFF
--- a/api-core-cms/src/main/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGenerator.java
+++ b/api-core-cms/src/main/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGenerator.java
@@ -434,23 +434,13 @@ public final class CmsKeyIdGenerator {
   }
 
   /**
-   * Simplified overload. Generate an identifier with the given staff id and current timestamp.
-   * 
-   * @param staffId the staffId
-   * @return the unique key from staffId
-   */
-  public static String generate(String staffId) {
-    return generate(staffId, new Date());
-  }
-
-  /**
    * Generate an identifier with the given staff id and current timestamp.
    * 
    * @param staffId three char staff id
    * @param ts timestamp to use
    * @return unique key from staff id and timestamp
    */
-  public static String generate(String staffId, final Date ts) {
+  protected static String generate(String staffId, final Date ts) {
     return makeKey(!StringUtils.isBlank(staffId) ? staffId : DEFAULT_USER_ID, ts);
   }
 

--- a/api-core-cms/src/test/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGeneratorTest.java
+++ b/api-core-cms/src/test/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGeneratorTest.java
@@ -306,10 +306,7 @@ public final class CmsKeyIdGeneratorTest {
   @Test
   public void generate_Args__String__Date() throws Exception {
     final String staffId = "0X5";
-    final Date ts = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2017-06-09 13:04:22");
-    final String actual = CmsKeyIdGenerator.generate(staffId, ts);
-    // final String expected = "06SoJiH0X5";
-    // assertThat(actual, is(equalTo(expected)));
+    final String actual = CmsKeyIdGenerator.getNextValue(staffId);
     assertThat(actual, is(not("")));
   }
 


### PR DESCRIPTION
…final Date ts) is made protected to use it only in tests