### PR TITLE
CALS-5654: query in Client object modified to skip Out of home placements with End Date

### DIFF
--- a/legacy-data-access/src/main/java/gov/ca/cwds/data/legacy/cms/entity/Client.java
+++ b/legacy-data-access/src/main/java/gov/ca/cwds/data/legacy/cms/entity/Client.java
@@ -52,7 +52,7 @@ import org.hibernate.annotations.Type;
           + " JOIN pe.outOfHomePlacements ohp"
           + " JOIN ohp.placementHome ph"
           + " WHERE ph.licenseNo = :licenseNumber AND c.identifier = :childId"
-          + " AND ohp.endDt is not null"
+          + " AND ohp.endDt is null"
 )
 @NamedQuery(
   name = "Client.findAll",
@@ -62,7 +62,7 @@ import org.hibernate.annotations.Type;
           + " JOIN pe.outOfHomePlacements ohp"
           + " JOIN ohp.placementHome ph"
           + " WHERE ph.licenseNo = :licenseNumber"
-          + " AND ohp.endDt is not null"
+          + " AND ohp.endDt is null"
           + " ORDER BY c.identifier "
 )
 @NamedQuery(
@@ -73,7 +73,7 @@ import org.hibernate.annotations.Type;
           + " JOIN pe.outOfHomePlacements ohp"
           + " JOIN ohp.placementHome ph"
           + " WHERE ph.id = :facilityId"
-          + " AND ohp.endDt is not null"
+          + " AND ohp.endDt is null"
 )
 @SuppressWarnings({"squid:S3437", "squid:S2160"})
 @Entity


### PR DESCRIPTION
### JIRA Issue Link
- https://osi-cwds.atlassian.net/browse/CALS-5654

### Technical Description
Query in Client object modified to skip Out of home placements with End Date. This change will modify behavior of Facility API in CALS so that only children with active out of home placement will be provided in Facility Profile CALS.

### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!---Please indicate why tests were not added.-->

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!---Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!---Describe impact on automated deployment if any. Put N/A if not applicable.-->
N/A

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->
N/A

### Checklist:
<!---Go over all the following points, and put an `x` in all the boxes that apply.-->
<!---If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
