### PR TITLE
CALS-5654: query in Client object modified to skip Placement Episodes with End Date

### DIFF
--- a/legacy-data-access/src/main/java/gov/ca/cwds/data/legacy/cms/entity/Client.java
+++ b/legacy-data-access/src/main/java/gov/ca/cwds/data/legacy/cms/entity/Client.java
@@ -53,6 +53,7 @@ import org.hibernate.annotations.Type;
           + " JOIN ohp.placementHome ph"
           + " WHERE ph.licenseNo = :licenseNumber AND c.identifier = :childId"
           + " AND ohp.endDt is null"
+          + " AND pe.plepsEndt is null"
 )
 @NamedQuery(
   name = "Client.findAll",
@@ -63,6 +64,7 @@ import org.hibernate.annotations.Type;
           + " JOIN ohp.placementHome ph"
           + " WHERE ph.licenseNo = :licenseNumber"
           + " AND ohp.endDt is null"
+          + " AND pe.plepsEndt is null"
           + " ORDER BY c.identifier "
 )
 @NamedQuery(
@@ -74,6 +76,7 @@ import org.hibernate.annotations.Type;
           + " JOIN ohp.placementHome ph"
           + " WHERE ph.id = :facilityId"
           + " AND ohp.endDt is null"
+          + " AND pe.plepsEndt is null"
 )
 @SuppressWarnings({"squid:S3437", "squid:S2160"})
 @Entity


### PR DESCRIPTION
### JIRA Issue Link
- https://osi-cwds.atlassian.net/browse/CALS-5654

### Technical Description
Query in Client object modified to skip Placement Episodes with End Date. This change will modify behavior of Facility API in CALS so that only children with active out of home placement will be provided in Facility Profile CALS.

### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!---Please indicate why tests were not added.-->

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!---Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!---Describe impact on automated deployment if any. Put N/A if not applicable.-->
N/A

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->
N/A