### PR TITLE
INT-1562 Implement Diminutive & Phonetic Matching in ES

### DIFF
--- a/api-core-cms/src/main/resources/elasticsearch/mapping/map_person_summary.json
+++ b/api-core-cms/src/main/resources/elasticsearch/mapping/map_person_summary.json
@@ -14,11 +14,31 @@
     },
     "first_name": {
       "type": "text",
-      "store": true
+      "store": true,
+      "fields": {
+            "phonetic": {
+              "type": "text",
+              "analyzer": "dbl_metaphone"
+            },
+            "diminutive": {
+              "type": "text",
+              "analyzer": "names_synonyms"
+            }
+          }
     },
     "last_name": {
       "type": "text",
-      "store": true
+      "store": true,
+      "fields": {
+            "phonetic": {
+              "type": "text",
+              "analyzer": "dbl_metaphone"
+            },
+            "diminutive": {
+              "type": "text",
+              "analyzer": "names_synonyms"
+            }
+          }
     },
     "middle_name": {
       "type": "text",
@@ -61,7 +81,17 @@
       "type": "text",
       "store": true,
       "analyzer": "autocomplete",
-      "search_analyzer": "standard"
+      "search_analyzer": "standard",
+      "fields": {
+            "phonetic": {
+              "type": "text",
+              "analyzer": "dbl_metaphone"
+            },
+            "diminutive": {
+              "type": "text",
+              "analyzer": "names_synonyms"
+            }
+          }
     },
     "sensitivity_indicator": {
       "type": "text",

--- a/api-core-cms/src/main/resources/elasticsearch/setting/people-summary-index-settings.json
+++ b/api-core-cms/src/main/resources/elasticsearch/setting/people-summary-index-settings.json
@@ -1,22 +1,49 @@
 {
-  "number_of_shards": 5,
-  "number_of_replicas": 1,
-  "analysis": {
-    "filter": {
-      "autocomplete_filter": {
-        "type": "edge_ngram",
-        "min_gram": 1,
-        "max_gram": 20
-      }
-    },
-    "analyzer": {
-      "autocomplete": {
-        "type": "custom",
-        "tokenizer": "standard",
-        "filter": [
-          "lowercase",
-          "autocomplete_filter"
-        ]
+  "settings": {
+    "number_of_shards": 5,
+    "number_of_replicas": 1,
+    "analysis": {
+      "filter": {
+        "autocomplete_filter": {
+          "type": "edge_ngram",
+          "min_gram": 1,
+          "max_gram": 20
+        },
+        "dbl_metaphone_filter": {
+          "type": "phonetic",
+          "encoder": "doublemetaphone",
+          "replace": false
+        },
+        "names_synonym_filter": {
+          "type": "synonym",
+          "synonyms_path": "names_synonyms.txt"
+        }
+      },
+      "analyzer": {
+        "autocomplete": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "autocomplete_filter"
+          ]
+        },
+        "dbl_metaphone": {
+          "tokenizer": "standard",
+          "filter": [
+            "standard",
+            "lowercase",
+            "dbl_metaphone_filter"
+          ]
+        },
+        "names_synonyms": {
+          "tokenizer": "standard",
+          "filter": [
+            "standard",
+            "lowercase",
+            "names_synonym_filter"
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
### JIRA Issue Link
- [INT-1562: Implement Diminutive & Phonetic Matching in ES](https://osi-cwds.atlassian.net/browse/INT-1562)

### Technical Description
Change in Elasticsearch Settings and Mapping for Intake people-summary Index to facilitate diminutive and phonetic search

### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
To implement this Story, the following steps need to be performed in each environment

1. Install elasticsearch analysis-phonetic plugin
2. Copy the following file (data for diminutive search) to the same directory where the elasticsearch.yml resides:
https://github.com/ca-cwds/dora/blob/development/docker-es-xpack/names_synonyms.txt
3. Update the settings for the people-summary index and update the mapping for person-summary
These will be checked in here https://github.com/ca-cwds/api-core/tree/master/api-core-cms/src/main/resources/elasticsearch
4. Run jobs to populate the people-summary index
5. Deploy Intake code that will contain the updated query using the new settings and mapping

Step 3 is what is being checked in.

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->

### Checklist:
<!---Go over all the following points, and put an `x` in all the boxes that apply.-->
<!---If you're unsure about any of these, don't hesitate to ask.-->
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
