### PR TITLE
HOT-2450 Spike: Create Elasticsearch queries to include address in Se…

### DIFF
--- a/api-core-cms/src/main/java/gov/ca/cwds/data/es/ElasticSearchPersonAddress.java
+++ b/api-core-cms/src/main/java/gov/ca/cwds/data/es/ElasticSearchPersonAddress.java
@@ -421,6 +421,16 @@ public class ElasticSearchPersonAddress extends ApiObjectIdentity
     return constructSearchableAddressToIndex();
   }
 
+  /**
+   * Getter for "autocomplete_city".
+   *
+   * @return city to be indexed for autocomplete search
+   */
+  @JsonProperty("autocomplete_city")
+  public String getAutocompleteCity() {
+    return this.city;
+  }
+
   @JsonIgnore
   public ElasticSearchSystemCode getCountySystemCode() {
     return county;

--- a/api-core-cms/src/test/java/gov/ca/cwds/data/es/ElasticSearchPersonAddressTest.java
+++ b/api-core-cms/src/test/java/gov/ca/cwds/data/es/ElasticSearchPersonAddressTest.java
@@ -312,6 +312,21 @@ public class ElasticSearchPersonAddressTest {
   }
 
   @Test
+  public void getAutocompleteCity_Args__() throws Exception {
+    String actual = target.getAutocompleteCity();
+    String expected = null;
+    assertThat(actual, is(equalTo(expected)));
+  }
+
+  @Test
+  public void getAutocompleteAddress_Args__String() throws Exception {
+    target.setCity("Abc");
+    String actual = target.getAutocompleteCity();
+    String expected = "Abc";
+    assertThat(actual, is(equalTo(expected)));
+  }
+
+  @Test
   public void getApiAdrAddressType_Args__() throws Exception {
     Short actual = target.getApiAdrAddressType();
     Short expected = null;


### PR DESCRIPTION
…arch

### JIRA Issue Link
- [HOT-2450 Spike: Create Elasticsearch queries to include address in Search](https://osi-cwds.atlassian.net/browse/HOT-2450)

### Technical Description
<!---Provide a technical description with context for those that don't know what this pull request is about.-->
Added a new field for Elasticsearch people-summary Index to facilitate Address search by autocomplete City

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!---Please indicate why tests were not added.-->

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!---Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!---Describe impact on automated deployment if any. Put N/A if not applicable.-->
N/A

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->
N/A