### PR TITLE
CANS-556 Converson UIID to base62Key

### DIFF
--- a/api-core-cms/src/main/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGenerator.java
+++ b/api-core-cms/src/main/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGenerator.java
@@ -112,6 +112,7 @@ import gov.ca.cwds.rest.services.ServiceException;
 @SuppressWarnings({"fb-contrib:MDM_THREAD_YIELD", "findbugs:UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
 public class CmsKeyIdGenerator {
 
+  private static final int LEN_KEYSTAFFID = 3;
   private static final int LEN_KEYTIMESTAMP = 7;
   private static final int LEN_UIIDSTAFFID = 6; // for converting a key to a UI identifier
   private static final int LEN_UIIDTIMESTAMP = 13;

--- a/api-core-cms/src/main/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGenerator.java
+++ b/api-core-cms/src/main/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGenerator.java
@@ -155,7 +155,7 @@ public class CmsKeyIdGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(CmsKeyIdGenerator.class);
   private static final String DEFAULT_USER_ID = "0X5";
   private static final Map<String, String> lastKeys =
-      new PassiveExpiringMap<>(20, TimeUnit.SECONDS, new ConcurrentHashMap<>(20107));
+    new PassiveExpiringMap<>(20, TimeUnit.SECONDS, new ConcurrentHashMap<>(20107));
 
   /**
    * Static class only, do not instantiate.
@@ -177,7 +177,7 @@ public class CmsKeyIdGenerator {
    */
   public static String getNextValue(String staffId) {
     return StaffGate.getStaffGate(StringUtils.isNotBlank(staffId) ? staffId : DEFAULT_USER_ID)
-        .getNextValue();
+      .getNextValue();
   }
 
   /**
@@ -188,7 +188,7 @@ public class CmsKeyIdGenerator {
    */
   public static String createTimestampStr(final Date ts) {
     return ts == null ? createTimestampStr()
-        : longToStrN(7, timestampToLong(getTimestampSeed(ts)), POWER_BASE62);
+      : longToStrN(7, timestampToLong(getTimestampSeed(ts)), POWER_BASE62);
   }
 
   /**
@@ -418,7 +418,7 @@ public class CmsKeyIdGenerator {
    *
    * @param key 10 character, base-62 legacy key
    * @return UI identifier in format 0000-0000-0000-0000000. If provided key is null or empty, then
-   *         null is returned.
+   * null is returned.
    */
   public static String getUIIdentifierFromKey(String key) {
     if (StringUtils.isBlank(key)) {
@@ -430,16 +430,41 @@ public class CmsKeyIdGenerator {
     LOGGER.trace("strTimestamp={}, strStaffId={}", tsB62, staffB62);
 
     final String tsB10 =
-        StringUtils.leftPad(String.valueOf(Base62.toBase10(tsB62)), LEN_UIIDTIMESTAMP, '0');
+      StringUtils.leftPad(String.valueOf(Base62.toBase10(tsB62)), LEN_UIIDTIMESTAMP, '0');
     final String staffB10 =
-        StringUtils.leftPad(String.valueOf(Base62.toBase10(staffB62)), LEN_UIIDSTAFFID, '0');
+      StringUtils.leftPad(String.valueOf(Base62.toBase10(staffB62)), LEN_UIIDSTAFFID, '0');
     LOGGER.trace("tsB10={}, staffB10={}", tsB10, staffB10);
 
     final StringBuilder buf = new StringBuilder();
     buf.append(tsB10, 0, 4).append('-').append(tsB10, 4, 8).append('-').append(tsB10, 8, 12)
-        .append('-').append(tsB10.substring(12)).append(staffB10);
+      .append('-').append(tsB10.substring(12)).append(staffB10);
 
     return buf.toString();
+  }
+
+  /**
+   * Converts UIID to base62Key
+   *
+   * @param uiIdentifier - UIID
+   * @return Base62 key
+   */
+  public static String getBase62Key(String uiIdentifier) {
+    if (StringUtils.isBlank(uiIdentifier)) {
+      return null;
+    }
+
+    if (!uiIdentifier.matches("\\d{4}-\\d{4}-\\d{4}-\\d{7}")) {
+      throw new IllegalArgumentException(
+        "uiIdentifier [" + uiIdentifier
+          + "] doesn't match to the pattern: \\d{4}-\\d{4}-\\d{4}-\\d{7}");
+    }
+
+    String noDashes = StringUtils.remove(uiIdentifier, '-');
+    long tsLong = Long.parseLong(noDashes.substring(0, LEN_UIIDTIMESTAMP));
+    long staffIdLong = Long.parseLong(noDashes.substring(LEN_UIIDTIMESTAMP));
+    String tsBase62 = StringUtils.leftPad(Base62.toBase62(tsLong), LEN_KEYTIMESTAMP, '0');
+    String staffIdBase62 = StringUtils.leftPad(Base62.toBase62(staffIdLong), LEN_KEYSTAFFID, '0');
+    return tsBase62 + staffIdBase62;
   }
 
   /**
@@ -463,8 +488,9 @@ public class CmsKeyIdGenerator {
     new PassiveExpiringMap<>(5, TimeUnit.MINUTES, new ConcurrentHashMap<>());
 
   /**
-   * Synchronize key generation on staff/user id. The same user can only generate one key at a time.
-   * 
+   * Synchronize key generation on staff/user id. The same user can only generate one key at a
+   * time.
+   *
    * @author CWDS API Team
    */
   static class StaffGate implements Serializable {
@@ -527,8 +553,9 @@ public class CmsKeyIdGenerator {
       StaffGate other = (StaffGate) obj;
       if (staffId == null) {
         return other.staffId == null;
-      } else
+      } else {
         return staffId.equals(other.staffId);
+      }
     }
 
   }

--- a/api-core-cms/src/test/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGeneratorTest.java
+++ b/api-core-cms/src/test/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGeneratorTest.java
@@ -11,6 +11,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import gov.ca.cwds.data.legacy.cms.CmsPersistentObject;
+import gov.ca.cwds.data.persistence.cms.CmsKeyIdGenerator.KeyDetail;
+import gov.ca.cwds.rest.services.ServiceException;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -30,16 +33,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import gov.ca.cwds.data.persistence.cms.CmsKeyIdGenerator.KeyDetail;
-import gov.ca.cwds.rest.services.ServiceException;
 
 /**
  * This JNI native library runs correctly on Linux Jenkins when libLZW.so and libstdc++.so.6 are
@@ -103,9 +103,9 @@ public final class CmsKeyIdGeneratorTest {
 
   private static final int GOOD_KEY_LEN = CmsPersistentObject.CMS_ID_LEN;
   private static final Pattern RGX_LEGACY_KEY =
-      Pattern.compile("([a-z0-9]{10})", Pattern.CASE_INSENSITIVE);
+    Pattern.compile("([a-z0-9]{10})", Pattern.CASE_INSENSITIVE);
   private static final Pattern RGX_LEGACY_TIMESTAMP =
-      Pattern.compile("([a-z0-9]{7})", Pattern.CASE_INSENSITIVE);
+    Pattern.compile("([a-z0-9]{7})", Pattern.CASE_INSENSITIVE);
 
   // ===================
   // GENERATE KEY:
@@ -182,7 +182,7 @@ public final class CmsKeyIdGeneratorTest {
   public void testGenKeyBadStaffTooLong() {
     // Wrong staff id length.
     final String key = CmsKeyIdGenerator
-        .getNextValue("ab7777d7d7d7s8283jh4jskksjajfkdjbjdjjjasdfkljcxmzxcvjdhshfjjdkksahf");
+      .getNextValue("ab7777d7d7d7s8283jh4jskksjajfkdjbjdjjjasdfkljcxmzxcvjdhshfjjdkksahf");
     // assertTrue("key generated", key == null || key.length() == 0);
   }
 
@@ -340,14 +340,14 @@ public final class CmsKeyIdGeneratorTest {
 
     final Date localDate = CmsKeyIdGenerator.getDateFromKey(thirdId);
     System.out.println(
-        "localDate: " + sdf.format(localDate) + ", dateFromXtools: " + sdf.format(dateFromXtools));
+      "localDate: " + sdf.format(localDate) + ", dateFromXtools: " + sdf.format(dateFromXtools));
 
     assertEquals(dateFromXtools.getTime(), localDate.getTime());
     assertEquals(thirdId, thirdIdFromXTools);
   }
 
   protected void iterateExpiringMap(Map<String, String> keepKey, Map<String, String> lastKey,
-      String[] staffIds, Date now, boolean add, boolean expired) {
+    String[] staffIds, Date now, boolean add, boolean expired) {
     for (String staffId : staffIds) {
       String expected = keepKey.get(staffId);
 
@@ -371,7 +371,7 @@ public final class CmsKeyIdGeneratorTest {
   @Test
   public void testPassiveExpiringMap() throws Exception {
     final Map<String, String> lastKey =
-        new PassiveExpiringMap<>(700, TimeUnit.MILLISECONDS, new ConcurrentHashMap<>());
+      new PassiveExpiringMap<>(700, TimeUnit.MILLISECONDS, new ConcurrentHashMap<>());
     final Map<String, String> keepKey = new HashMap<>();
 
     final String[] staffIds = {"aaa", "aab", "aac", "aad", "aae", "aaf", "aag", "aah"};
@@ -465,7 +465,7 @@ public final class CmsKeyIdGeneratorTest {
   // }
 
   private void genKeys(String staffId, int threadNum, int keysPerThread,
-      Map<String, String> results) {
+    Map<String, String> results) {
     Thread.currentThread().setName(staffId + '_' + threadNum);
     LOGGER.info("START: staff id: {}", staffId);
 
@@ -481,7 +481,7 @@ public final class CmsKeyIdGeneratorTest {
 
     if (keysGenerated != keysPerThread) {
       LOGGER.error("KEY COUNT MISMATCH! staff id: {}, counter: {}, keysPerThread: {}",
-          keysGenerated, keysPerThread);
+        keysGenerated, keysPerThread);
     }
     LOGGER.info("STOP:  staff id: {}, keys generated: {}", staffId, keysGenerated);
   }
@@ -497,7 +497,7 @@ public final class CmsKeyIdGeneratorTest {
     final Date start = new Date();
 
     final List<String> staffIds = IntStream.rangeClosed(1, numberOfUsers).boxed()
-        .map(i -> StringUtils.leftPad(String.valueOf(i + 1), 3, "b")).collect(Collectors.toList());
+      .map(i -> StringUtils.leftPad(String.valueOf(i + 1), 3, "b")).collect(Collectors.toList());
     final Map<String, String> results = new ConcurrentHashMap<>(expectedCount);
 
     // It's a unit test, not a stress test. Jenkins doesn't have CPU to spare.
@@ -519,10 +519,24 @@ public final class CmsKeyIdGeneratorTest {
 
     final int actual = results.size();
     LOGGER.info("Time (milis): {}, expected keys: {}, actual keys: {}",
-        (System.currentTimeMillis() - start.getTime()), expectedCount, actual);
+      (System.currentTimeMillis() - start.getTime()), expectedCount, actual);
 
     assertEquals("Number of unique IDs generated NOT equals to total number of IDs generated.",
-        expectedCount, actual);
+      expectedCount, actual);
+  }
+
+  @Test
+  public void toBase62KeyTest() {
+    Assert.assertThat("AfiTGrO0ND",
+      is(equalTo(CmsKeyIdGenerator.getBase62Key("0606-2209-3706-2001439"))));
+    Assert.assertThat("ANkfTZy75C",
+      is(equalTo(CmsKeyIdGenerator.getBase62Key("0589-7630-0758-6027230"))));
+    Assert.assertThat("ANkfTZy75D",
+      is(equalTo(CmsKeyIdGenerator.getBase62Key("0589-7630-0758-6027231"))));
+    Assert.assertThat("AWbb5yZzzz",
+      is(equalTo(CmsKeyIdGenerator.getBase62Key("0597-8741-7200-7238327"))));
+    Assert.assertThat("0YIPkZU0S0",
+      is(equalTo(CmsKeyIdGenerator.getBase62Key("0031-4206-2756-0001736"))));
   }
 
 }

--- a/api-core-cms/src/test/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGeneratorTest.java
+++ b/api-core-cms/src/test/java/gov/ca/cwds/data/persistence/cms/CmsKeyIdGeneratorTest.java
@@ -526,7 +526,7 @@ public final class CmsKeyIdGeneratorTest {
   }
 
   @Test
-  public void toBase62KeyTest() {
+  public void toBase62KeyTest_success() {
     Assert.assertThat("AfiTGrO0ND",
       is(equalTo(CmsKeyIdGenerator.getBase62Key("0606-2209-3706-2001439"))));
     Assert.assertThat("ANkfTZy75C",
@@ -537,6 +537,23 @@ public final class CmsKeyIdGeneratorTest {
       is(equalTo(CmsKeyIdGenerator.getBase62Key("0597-8741-7200-7238327"))));
     Assert.assertThat("0YIPkZU0S0",
       is(equalTo(CmsKeyIdGenerator.getBase62Key("0031-4206-2756-0001736"))));
+  }
+
+  @Test
+  public void toBase62KeyTest_do_not_matches_fail() {
+    try{
+      CmsKeyIdGenerator.getBase62Key("some-text");
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      LOGGER.info(e.getMessage());
+    }
+
+    try{
+      CmsKeyIdGenerator.getBase62Key("O589-7630-0758-6027230");
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      LOGGER.info(e.getMessage());
+    }
   }
 
 }


### PR DESCRIPTION
### JIRA Issue Link
- [CANS-556: Create ETL app/program/job to convert UIID to Base62 (primary key in CWS/CMS) id for people table, and case external ids for Assessments table](https://osi-cwds.atlassian.net/browse/CANS-556)

### Technical Description
Conversion UIID to base62Key

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!---Please indicate why tests were not added.-->

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!---Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!---Describe impact on automated deployment if any. Put N/A if not applicable.-->
N/A

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->
N/A