### PR TITLE
SEAR-475 CALS API: Get rid of using XA transaction for read-only queries

### DIFF
--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/ApplicationAndLicenseStatusHistoryDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/ApplicationAndLicenseStatusHistoryDao.java
@@ -1,0 +1,16 @@
+package gov.ca.cwds.cms.data.access.dao;
+
+import com.google.inject.Inject;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
+import gov.ca.cwds.data.BaseDaoImpl;
+import gov.ca.cwds.data.legacy.cms.entity.ApplicationAndLicenseStatusHistory;
+import org.hibernate.SessionFactory;
+
+public class ApplicationAndLicenseStatusHistoryDao extends
+  BaseDaoImpl<ApplicationAndLicenseStatusHistory> {
+
+  @Inject
+  public ApplicationAndLicenseStatusHistoryDao(@XaDasSessionFactory SessionFactory sessionFactory) {
+    super(sessionFactory);
+  }
+}

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/BackgroundCheckDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/BackgroundCheckDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.BackgroundCheck;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class BackgroundCheckDao extends BaseDaoImpl<BackgroundCheck> {
 
   @Inject
-  public BackgroundCheckDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public BackgroundCheckDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/CountyLicenseCaseDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/CountyLicenseCaseDao.java
@@ -3,19 +3,16 @@ package gov.ca.cwds.cms.data.access.dao;
 import com.google.inject.Inject;
 import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
-import gov.ca.cwds.data.legacy.cms.entity.OtherChildrenInPlacementHome;
+import gov.ca.cwds.data.legacy.cms.entity.CountyLicenseCase;
 import org.hibernate.SessionFactory;
 
 /**
  * @author CWDS CALS API Team
  */
-
-public class OtherChildrenInPlacementHomeDao extends BaseDaoImpl<OtherChildrenInPlacementHome> {
+public class CountyLicenseCaseDao extends BaseDaoImpl<CountyLicenseCase> {
 
   @Inject
-  public OtherChildrenInPlacementHomeDao(@XaDasSessionFactory SessionFactory sessionFactory) {
+  public CountyLicenseCaseDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
-
 }
-

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/CountyLicenseCaseDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/CountyLicenseCaseDao.java
@@ -7,6 +7,7 @@ import gov.ca.cwds.data.legacy.cms.entity.CountyLicenseCase;
 import org.hibernate.SessionFactory;
 
 /**
+ * CountyLicenseCaseDao.
  * @author CWDS CALS API Team
  */
 public class CountyLicenseCaseDao extends BaseDaoImpl<CountyLicenseCase> {

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/CountyOwnershipDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/CountyOwnershipDao.java
@@ -1,12 +1,10 @@
 package gov.ca.cwds.cms.data.access.dao;
 
-import org.hibernate.SessionFactory;
-
 import com.google.inject.Inject;
-
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.CountyOwnership;
+import org.hibernate.SessionFactory;
 
 /**
  * @author CWDS CALS API Team
@@ -14,7 +12,7 @@ import gov.ca.cwds.data.legacy.cms.entity.CountyOwnership;
 public class CountyOwnershipDao extends BaseDaoImpl<CountyOwnership> {
 
   @Inject
-  public CountyOwnershipDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public CountyOwnershipDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/EmergencyContactDetailDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/EmergencyContactDetailDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.EmergencyContactDetail;
 import org.hibernate.SessionFactory;
@@ -12,7 +12,7 @@ import org.hibernate.SessionFactory;
 public class EmergencyContactDetailDao extends BaseDaoImpl<EmergencyContactDetail> {
 
   @Inject
-  public EmergencyContactDetailDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public EmergencyContactDetailDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/ExternalInterfaceDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/ExternalInterfaceDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.ExternalInterface;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class ExternalInterfaceDao extends BaseDaoImpl<ExternalInterface> {
 
   @Inject
-  public ExternalInterfaceDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public ExternalInterfaceDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/OtherAdultsInPlacementHomeDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/OtherAdultsInPlacementHomeDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.OtherAdultsInPlacementHome;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class OtherAdultsInPlacementHomeDao extends BaseDaoImpl<OtherAdultsInPlacementHome> {
 
   @Inject
-  public OtherAdultsInPlacementHomeDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public OtherAdultsInPlacementHomeDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/OtherPeopleScpRelationshipDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/OtherPeopleScpRelationshipDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.OtherPeopleScpRelationship;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class OtherPeopleScpRelationshipDao extends BaseDaoImpl<OtherPeopleScpRelationship> {
 
   @Inject
-  public OtherPeopleScpRelationshipDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public OtherPeopleScpRelationshipDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/OutOfStateCheckDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/OutOfStateCheckDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.OutOfStateCheck;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class OutOfStateCheckDao extends BaseDaoImpl<OutOfStateCheck> {
 
   @Inject
-  public OutOfStateCheckDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public OutOfStateCheckDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PhoneContactDetailDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PhoneContactDetailDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.PhoneContactDetail;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class PhoneContactDetailDao extends BaseDaoImpl<PhoneContactDetail> {
 
   @Inject
-  public PhoneContactDetailDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public PhoneContactDetailDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementFacilityTypeHistoryDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementFacilityTypeHistoryDao.java
@@ -1,14 +1,14 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.PlacementFacilityTypeHistory;
 import org.hibernate.SessionFactory;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
 
 public class PlacementFacilityTypeHistoryDao extends BaseDaoImpl<PlacementFacilityTypeHistory> {
     @Inject
-    public PlacementFacilityTypeHistoryDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+    public PlacementFacilityTypeHistoryDao(@XaDasSessionFactory SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 }

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementHomeDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementHomeDao.java
@@ -1,17 +1,14 @@
 package gov.ca.cwds.cms.data.access.dao;
 
+import com.google.inject.Inject;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
+import gov.ca.cwds.data.BaseDaoImpl;
+import gov.ca.cwds.data.legacy.cms.entity.PlacementHome;
 import javax.persistence.NoResultException;
-
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.inject.Inject;
-
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
-import gov.ca.cwds.data.BaseDaoImpl;
-import gov.ca.cwds.data.legacy.cms.entity.PlacementHome;
 
 /**
  * @author CWDS CALS API Team
@@ -21,7 +18,7 @@ public class PlacementHomeDao extends BaseDaoImpl<PlacementHome> {
   private static final Logger LOG = LoggerFactory.getLogger(PlacementHomeDao.class);
 
   @Inject
-  public PlacementHomeDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public PlacementHomeDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementHomeInformationDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementHomeInformationDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.PlacementHomeInformation;
 import org.hibernate.SessionFactory;
@@ -14,7 +14,7 @@ public class PlacementHomeInformationDao extends BaseDaoImpl<PlacementHomeInform
 
   @Inject
   public PlacementHomeInformationDao(
-      @DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+    @XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementHomeProfileDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/PlacementHomeProfileDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.PlacementHomeProfile;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class PlacementHomeProfileDao extends BaseDaoImpl<PlacementHomeProfile> {
 
   @Inject
-  public PlacementHomeProfileDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public PlacementHomeProfileDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/ScpOtherEthnicityDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/ScpOtherEthnicityDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.ScpOtherEthnicity;
 import org.hibernate.SessionFactory;
@@ -13,7 +13,7 @@ import org.hibernate.SessionFactory;
 public class ScpOtherEthnicityDao extends BaseDaoImpl<ScpOtherEthnicity> {
 
   @Inject
-  public ScpOtherEthnicityDao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public ScpOtherEthnicityDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 }

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/SsaName3Dao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/SsaName3Dao.java
@@ -1,10 +1,8 @@
 package gov.ca.cwds.cms.data.access.dao;
 
-import org.hibernate.SessionFactory;
-
 import com.google.inject.Inject;
-
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
+import org.hibernate.SessionFactory;
 
 /**
  * @author CWDS CALS API Team
@@ -12,7 +10,7 @@ import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
 public class SsaName3Dao extends gov.ca.cwds.data.legacy.cms.dao.SsaName3Dao {
 
   @Inject
-  public SsaName3Dao(@DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+  public SsaName3Dao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/StaffPersonDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/StaffPersonDao.java
@@ -7,7 +7,7 @@ import gov.ca.cwds.data.legacy.cms.entity.StaffPerson;
 import org.hibernate.SessionFactory;
 
 /**
- * Created by Alexander Serbin on 12/12/2018
+ * Created by Alexander Serbin on 12/12/2018.
  */
 public class StaffPersonDao extends BaseDaoImpl<StaffPerson> {
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/StaffPersonDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/StaffPersonDao.java
@@ -3,19 +3,17 @@ package gov.ca.cwds.cms.data.access.dao;
 import com.google.inject.Inject;
 import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
-import gov.ca.cwds.data.legacy.cms.entity.PlacementHomeUc;
+import gov.ca.cwds.data.legacy.cms.entity.StaffPerson;
 import org.hibernate.SessionFactory;
 
 /**
- * @author CWDS CALS API Team
+ * Created by Alexander Serbin on 12/12/2018
  */
-
-public class PlacementHomeUcDao extends BaseDaoImpl<PlacementHomeUc> {
+public class StaffPersonDao extends BaseDaoImpl<StaffPerson> {
 
   @Inject
-  public PlacementHomeUcDao(@XaDasSessionFactory SessionFactory sessionFactory) {
+  public StaffPersonDao(@XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 
 }
-

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/SubstituteCareProviderDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/SubstituteCareProviderDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.SubstituteCareProvider;
 import org.hibernate.SessionFactory;
@@ -14,7 +14,7 @@ public class SubstituteCareProviderDao extends BaseDaoImpl<SubstituteCareProvide
 
   @Inject
   public SubstituteCareProviderDao(
-      @DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+    @XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/SubstituteCareProviderUcDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/SubstituteCareProviderUcDao.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.cms.data.access.dao;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.cms.data.access.inject.DataAccessServicesSessionFactory;
+import gov.ca.cwds.cms.data.access.inject.XaDasSessionFactory;
 import gov.ca.cwds.data.BaseDaoImpl;
 import gov.ca.cwds.data.legacy.cms.entity.SubstituteCareProviderUc;
 import org.hibernate.SessionFactory;
@@ -14,7 +14,7 @@ public class SubstituteCareProviderUcDao extends BaseDaoImpl<SubstituteCareProvi
 
   @Inject
   public SubstituteCareProviderUcDao(
-      @DataAccessServicesSessionFactory SessionFactory sessionFactory) {
+    @XaDasSessionFactory SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/nonxa/NonXaPlacementHomeDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/nonxa/NonXaPlacementHomeDao.java
@@ -1,0 +1,22 @@
+package gov.ca.cwds.cms.data.access.dao.nonxa;
+
+import com.google.inject.Inject;
+import gov.ca.cwds.cms.data.access.dao.PlacementHomeDao;
+import gov.ca.cwds.cms.data.access.inject.NonXaDasSessionFactory;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author CWDS CALS API Team
+ */
+public class NonXaPlacementHomeDao extends PlacementHomeDao {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NonXaPlacementHomeDao.class);
+
+  @Inject
+  public NonXaPlacementHomeDao(@NonXaDasSessionFactory SessionFactory sessionFactory) {
+    super(sessionFactory);
+  }
+
+}

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/nonxa/NonXaPlacementHomeDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/nonxa/NonXaPlacementHomeDao.java
@@ -6,6 +6,7 @@ import gov.ca.cwds.cms.data.access.inject.NonXaDasSessionFactory;
 import org.hibernate.SessionFactory;
 
 /**
+ * NonXaPlacementHomeDao.
  * @author CWDS CALS API Team.
  */
 public class NonXaPlacementHomeDao extends PlacementHomeDao {

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/nonxa/NonXaPlacementHomeDao.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/dao/nonxa/NonXaPlacementHomeDao.java
@@ -4,15 +4,11 @@ import com.google.inject.Inject;
 import gov.ca.cwds.cms.data.access.dao.PlacementHomeDao;
 import gov.ca.cwds.cms.data.access.inject.NonXaDasSessionFactory;
 import org.hibernate.SessionFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * @author CWDS CALS API Team
+ * @author CWDS CALS API Team.
  */
 public class NonXaPlacementHomeDao extends PlacementHomeDao {
-
-  private static final Logger LOG = LoggerFactory.getLogger(NonXaPlacementHomeDao.class);
 
   @Inject
   public NonXaPlacementHomeDao(@NonXaDasSessionFactory SessionFactory sessionFactory) {

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/inject/AbstractDataAccessServicesModule.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/inject/AbstractDataAccessServicesModule.java
@@ -1,12 +1,9 @@
 package gov.ca.cwds.cms.data.access.inject;
 
-import org.hibernate.SessionFactory;
-
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
-
 import gov.ca.cwds.cms.data.access.mapper.ClientMapper;
 import gov.ca.cwds.cms.data.access.mapper.CountyOwnershipMapper;
 import gov.ca.cwds.cms.data.access.mapper.ExternalInterfaceMapper;
@@ -21,6 +18,7 @@ import gov.ca.cwds.cms.data.access.service.impl.SubstituteCareProviderCoreServic
 import gov.ca.cwds.cms.data.access.service.impl.clientrelationship.ClientRelationshipCoreService;
 import gov.ca.cwds.cms.data.access.service.impl.tribalmembership.CreateLifeCycle;
 import gov.ca.cwds.cms.data.access.service.impl.tribalmembership.TribalMembershipVerificationCoreService;
+import org.hibernate.SessionFactory;
 
 /**
  * Common module binds services for authorization, common client services, and singleton instances.
@@ -37,19 +35,51 @@ public abstract class AbstractDataAccessServicesModule extends AbstractModule {
   }
 
   @Provides
-  @DataAccessServicesSessionFactory
+  @XaDasSessionFactory
   @Inject
-  protected SessionFactory dataAccessServicesSessionFactory(Injector injector) {
-    return getDataAccessServicesSessionFactory(injector);
+  protected SessionFactory xaSessionFactory(Injector injector) {
+    return getXaSessionFactory(injector);
+  }
+
+  @Provides
+  @NonXaDasSessionFactory
+  @Inject
+  protected SessionFactory nonXaSessionFactory(Injector injector) {
+    return getNotXaSessionFactory(injector);
   }
 
   /**
-   * Child classes must provide an appropriate session factory for authorization services.
+   * Child classes must provide an appropriate session factory for data access services.
+   * Use this method when you have only one session factory
    *
    * @param injector Guice injector
    * @return appropriate session factory
    */
-  protected abstract SessionFactory getDataAccessServicesSessionFactory(Injector injector);
+  protected SessionFactory getDataAccessServicesSessionFactory(Injector injector) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Child classes must provide an appropriate session factory for data access services.
+   * Use this method when you have both XA and non-XA session factories
+   *
+   * @param injector Guice injector
+   * @return appropriate session factory
+   */
+  protected SessionFactory getXaSessionFactory(Injector injector) {
+    return getDataAccessServicesSessionFactory(injector);
+  }
+
+  /**
+   * Child classes must provide an appropriate session factory for data access services.
+   * Use this method when you have both XA and non-XA session factories
+   *
+   * @param injector Guice injector
+   * @return appropriate session factory
+   */
+  protected SessionFactory getNotXaSessionFactory(Injector injector) {
+    return getDataAccessServicesSessionFactory(injector);
+  }
 
   protected void configureDataAccessServices() {
     bind(PlacementHomeCoreService.class);

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/inject/NonXaDasSessionFactory.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/inject/NonXaDasSessionFactory.java
@@ -17,5 +17,5 @@ import java.lang.annotation.Target;
 @BindingAnnotation
 @Target({FIELD, PARAMETER, METHOD})
 @Retention(RUNTIME)
-public @interface DataAccessServicesSessionFactory {
+public @interface NonXaDasSessionFactory {
 }

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/inject/XaDasSessionFactory.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/inject/XaDasSessionFactory.java
@@ -1,0 +1,22 @@
+package gov.ca.cwds.cms.data.access.inject;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.google.inject.BindingAnnotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for binding to our Legacy System database.
+ *
+ * @author CWDS API Team
+ */
+@BindingAnnotation
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+public @interface XaDasSessionFactory {
+
+}

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/DataAccessService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/DataAccessService.java
@@ -1,14 +1,19 @@
 package gov.ca.cwds.cms.data.access.service;
 
-import java.io.Serializable;
-
 import gov.ca.cwds.cms.data.access.dto.BaseEntityAwareDTO;
 import gov.ca.cwds.data.persistence.PersistentObject;
+import java.io.Serializable;
 
-/** @author CWDS CALS API Team */
+/**
+ * @author CWDS CALS API Team
+ */
 public interface DataAccessService<T extends PersistentObject, P extends BaseEntityAwareDTO<T>> {
 
   default T find(Serializable primaryKey) {
+    throw new UnsupportedOperationException();
+  }
+
+  default T xaFind(Serializable primaryKey) {
     throw new UnsupportedOperationException();
   }
 
@@ -16,11 +21,23 @@ public interface DataAccessService<T extends PersistentObject, P extends BaseEnt
     throw new UnsupportedOperationException();
   }
 
+  default T xaCreate(P entityAwareDTO) throws DataAccessServicesException {
+    throw new UnsupportedOperationException();
+  }
+
   default T update(P entityAwareDTO) throws DataAccessServicesException {
     throw new UnsupportedOperationException();
   }
 
+  default T xaUpdate(P entityAwareDTO) throws DataAccessServicesException {
+    throw new UnsupportedOperationException();
+  }
+
   default T delete(Serializable primaryKey) {
+    throw new UnsupportedOperationException();
+  }
+
+  default T xaDelete(Serializable primaryKey) {
     throw new UnsupportedOperationException();
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/DataAccessService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/DataAccessService.java
@@ -17,19 +17,19 @@ public interface DataAccessService<T extends PersistentObject, P extends BaseEnt
     throw new UnsupportedOperationException();
   }
 
-  default T create(P entityAwareDTO) throws DataAccessServicesException {
+  default T create(P entityAwareDto) throws DataAccessServicesException {
     throw new UnsupportedOperationException();
   }
 
-  default T xaCreate(P entityAwareDTO) throws DataAccessServicesException {
+  default T xaCreate(P entityAwareDto) throws DataAccessServicesException {
     throw new UnsupportedOperationException();
   }
 
-  default T update(P entityAwareDTO) throws DataAccessServicesException {
+  default T update(P entityAwareDto) throws DataAccessServicesException {
     throw new UnsupportedOperationException();
   }
 
-  default T xaUpdate(P entityAwareDTO) throws DataAccessServicesException {
+  default T xaUpdate(P entityAwareDto) throws DataAccessServicesException {
     throw new UnsupportedOperationException();
   }
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/DataAccessService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/DataAccessService.java
@@ -5,6 +5,7 @@ import gov.ca.cwds.data.persistence.PersistentObject;
 import java.io.Serializable;
 
 /**
+ * Interface for legacy data access services.
  * @author CWDS CALS API Team
  */
 public interface DataAccessService<T extends PersistentObject, P extends BaseEntityAwareDTO<T>> {

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/ApplicationAndLicenseStatusHistoryService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/ApplicationAndLicenseStatusHistoryService.java
@@ -1,9 +1,8 @@
 package gov.ca.cwds.cms.data.access.service.impl;
 
 import com.google.inject.Inject;
+import gov.ca.cwds.cms.data.access.dao.ApplicationAndLicenseStatusHistoryDao;
 import gov.ca.cwds.cms.data.access.dto.AppAndLicHistoryAwareDTO;
-import gov.ca.cwds.cms.data.access.service.DefaultCmsDataAccessService;
-import gov.ca.cwds.data.legacy.cms.dao.ApplicationAndLicenseStatusHistoryDao;
 import gov.ca.cwds.data.legacy.cms.entity.ApplicationAndLicenseStatusHistory;
 import java.util.function.Consumer;
 

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/ClientCoreService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/ClientCoreService.java
@@ -3,26 +3,11 @@ package gov.ca.cwds.cms.data.access.service.impl;
 import static gov.ca.cwds.authorizer.ClientResultReadAuthorizer.CLIENT_RESULT_READ_OBJECT;
 import static gov.ca.cwds.cms.data.access.Constants.Authorize.CLIENT_READ_CLIENT;
 
-import java.io.Serializable;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import com.google.inject.Inject;
-
 import gov.ca.cwds.cms.data.access.Constants;
 import gov.ca.cwds.cms.data.access.dto.ClientEntityAwareDTO;
 import gov.ca.cwds.cms.data.access.dto.OtherClientNameDTO;
 import gov.ca.cwds.cms.data.access.service.BusinessValidationService;
-import gov.ca.cwds.cms.data.access.service.DataAccessServiceBase;
-import gov.ca.cwds.cms.data.access.service.DataAccessServicesException;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessBundle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DefaultDataAccessLifeCycle;
@@ -50,6 +35,17 @@ import gov.ca.cwds.data.legacy.cms.entity.SafetyAlert;
 import gov.ca.cwds.security.annotations.Authorize;
 import gov.ca.cwds.security.realm.PerryAccount;
 import gov.ca.cwds.security.utils.PrincipalUtils;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** @author CWDS TPT-3 Team */
 public class ClientCoreService
@@ -97,11 +93,6 @@ public class ClientCoreService
   }
 
   @Override
-  public Client create(ClientEntityAwareDTO entityAwareDTO) throws DataAccessServicesException {
-    return super.create(entityAwareDTO);
-  }
-
-  @Override
   @Authorize(CLIENT_READ_CLIENT)
   public Client find(Serializable primaryKey) {
     return super.find(primaryKey);
@@ -109,29 +100,29 @@ public class ClientCoreService
 
   @Authorize(CLIENT_RESULT_READ_OBJECT)
   public Client getClientByLicNumAndChildId(String licenseNumber, String childId) {
-    return crudDao.findByLicNumAndChildId(licenseNumber, childId);
+    return getCrudDao(true).findByLicNumAndChildId(licenseNumber, childId);
   }
 
   @Authorize(CLIENT_RESULT_READ_OBJECT)
   public Client getClientByFacilityIdAndChildId(String facilityId, String childId) {
-    return crudDao.findByFacilityIdAndChildId(facilityId, childId);
+    return getCrudDao(true).findByFacilityIdAndChildId(facilityId, childId);
   }
 
   @Authorize(CLIENT_RESULT_READ_OBJECT)
   public List<Client> getClientsByLicenseNumber(String licenseNumber) {
-    Stream<Client> clients = crudDao.streamByLicenseNumber(licenseNumber);
+    Stream<Client> clients = getCrudDao(true).streamByLicenseNumber(licenseNumber);
     return clients.collect(Collectors.toList());
   }
 
   @Authorize(CLIENT_RESULT_READ_OBJECT)
   public List<Client> getClientsByLicenseNumber(Integer licenseNumber) {
-    Stream<Client> clients = crudDao.streamByLicenseNumber(licenseNumber);
+    Stream<Client> clients = getCrudDao(true).streamByLicenseNumber(licenseNumber);
     return clients.collect(Collectors.toList());
   }
 
   @Authorize(CLIENT_RESULT_READ_OBJECT)
   public List<Client> streamByFacilityId(String facilityId) {
-    Stream<Client> clients = crudDao.streamByFacilityId(facilityId);
+    Stream<Client> clients = getCrudDao(true).streamByFacilityId(facilityId);
     return clients.collect(Collectors.toList());
   }
 
@@ -165,7 +156,7 @@ public class ClientCoreService
       List<NearFatality> nearFatalities = nearFatalityDao.findNearFatalitiesByClientId(clientId);
       clientEntityAwareDTO.getNearFatalities().addAll(nearFatalities);
 
-      Client persistentClientState = crudDao.find(clientId);
+      Client persistentClientState = getCrudDao(true).find(clientId);
       clientEntityAwareDTO.setPersistentClientState(persistentClientState);
 
       Short nameTypeId = clientEntityAwareDTO.getEntity().getNameType().getSystemId();
@@ -232,7 +223,7 @@ public class ClientCoreService
     private void enrichExistingOtherEthnicities(Client client) {
       String clientId = client.getIdentifier();
 
-      Client persistedClient = crudDao.find(clientId);
+      Client persistedClient = getCrudDao(true).find(clientId);
       Map<Short, ClientOtherEthnicity> persistedEthnicitiesMap =
           getOtherEthnicityMap(persistedClient.getOtherEthnicities());
       Map<Short, ClientOtherEthnicity> ethnicitiesMap =

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/CountyLicenseCaseService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/CountyLicenseCaseService.java
@@ -1,12 +1,11 @@
 package gov.ca.cwds.cms.data.access.service.impl;
 
 import com.google.inject.Inject;
+import gov.ca.cwds.cms.data.access.dao.CountyLicenseCaseDao;
 import gov.ca.cwds.cms.data.access.dto.CLCEntityAwareDTO;
-import gov.ca.cwds.cms.data.access.service.DataAccessServiceBase;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessBundle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DefaultDataAccessLifeCycle;
-import gov.ca.cwds.data.legacy.cms.dao.CountyLicenseCaseDao;
 import gov.ca.cwds.data.legacy.cms.entity.CountyLicenseCase;
 
 /** @author CWDS TPT-3 Team */

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/DataAccessServiceBase.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/DataAccessServiceBase.java
@@ -54,13 +54,13 @@ public abstract class DataAccessServiceBase<E extends CrudsDao<T>, T extends Per
   }
 
   @Override
-  public T create(P entityAwareDTO) throws DataAccessServicesException {
-    return create(entityAwareDTO, false);
+  public T create(P entityAwareDto) throws DataAccessServicesException {
+    return create(entityAwareDto, false);
   }
 
   @Override
-  public T xaCreate(P entityAwareDTO) throws DataAccessServicesException {
-    return create(entityAwareDTO, true);
+  public T xaCreate(P entityAwareDto) throws DataAccessServicesException {
+    return create(entityAwareDto, true);
   }
 
   T create(P entityAwareDTO, boolean isXaTransaction) throws DataAccessServicesException {
@@ -87,13 +87,13 @@ public abstract class DataAccessServiceBase<E extends CrudsDao<T>, T extends Per
   }
 
   @Override
-  public T update(P entityAwareDTO) throws DataAccessServicesException {
-    return update(entityAwareDTO, false);
+  public T update(P entityAwareDto) throws DataAccessServicesException {
+    return update(entityAwareDto, false);
   }
 
   @Override
-  public T xaUpdate(P entityAwareDTO) throws DataAccessServicesException {
-    return update(entityAwareDTO, true);
+  public T xaUpdate(P entityAwareDto) throws DataAccessServicesException {
+    return update(entityAwareDto, true);
   }
 
   T update(P entityAwareDTO, boolean isXaTransaction) throws DataAccessServicesException {

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/DefaultCmsDataAccessService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/DefaultCmsDataAccessService.java
@@ -1,15 +1,14 @@
-package gov.ca.cwds.cms.data.access.service;
-
-import java.time.LocalDateTime;
-import java.util.function.Consumer;
+package gov.ca.cwds.cms.data.access.service.impl;
 
 import gov.ca.cwds.cms.data.access.dto.BaseEntityAwareDTO;
-import gov.ca.cwds.cms.data.access.service.impl.IdGenerator;
+import gov.ca.cwds.cms.data.access.service.DataAccessServicesException;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DefaultDataAccessLifeCycle;
 import gov.ca.cwds.data.CrudsDao;
 import gov.ca.cwds.data.legacy.cms.CmsPersistentObject;
 import gov.ca.cwds.security.utils.PrincipalUtils;
+import java.time.LocalDateTime;
+import java.util.function.Consumer;
 
 public abstract class DefaultCmsDataAccessService<E extends CrudsDao<T>, T extends CmsPersistentObject, P extends BaseEntityAwareDTO<T>>
     extends DataAccessServiceBase<E, T, P> {
@@ -26,11 +25,11 @@ public abstract class DefaultCmsDataAccessService<E extends CrudsDao<T>, T exten
    * @throws DataAccessServicesException if something went wrong
    */
   @Override
-  public T create(P entityAwareDTO) throws DataAccessServicesException {
+  T create(P entityAwareDTO, boolean isXaTransaction) throws DataAccessServicesException {
     T entity = entityAwareDTO.getEntity();
     idSetter(entity).accept(IdGenerator.generateId());
     audit(entity);
-    return super.create(entityAwareDTO);
+    return super.create(entityAwareDTO, isXaTransaction);
   }
 
   /**
@@ -41,9 +40,9 @@ public abstract class DefaultCmsDataAccessService<E extends CrudsDao<T>, T exten
    * @throws DataAccessServicesException if something went wrong
    */
   @Override
-  public T update(P entityAwareDTO) throws DataAccessServicesException {
+  protected T update(P entityAwareDTO, boolean isXaTransaction) throws DataAccessServicesException {
     audit(entityAwareDTO.getEntity());
-    return super.update(entityAwareDTO);
+    return super.update(entityAwareDTO, isXaTransaction);
   }
 
   @Override

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/StaffPersonService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/StaffPersonService.java
@@ -14,9 +14,9 @@ public class StaffPersonService
     extends DataAccessServiceBase<StaffPersonDao, StaffPerson, StaffPersonEntityAwareDTO> {
 
   @Override
-  public StaffPerson create(StaffPersonEntityAwareDTO entityAwareDTO)
+  public StaffPerson create(StaffPersonEntityAwareDTO entityAwareDto)
       throws DataAccessServicesException {
-    return super.create(entityAwareDTO);
+    return super.create(entityAwareDto);
   }
 
   @Inject

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/StaffPersonService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/StaffPersonService.java
@@ -1,16 +1,13 @@
 package gov.ca.cwds.cms.data.access.service.impl;
 
-import java.io.Serializable;
-
 import com.google.inject.Inject;
-
+import gov.ca.cwds.cms.data.access.dao.StaffPersonDao;
 import gov.ca.cwds.cms.data.access.dto.StaffPersonEntityAwareDTO;
-import gov.ca.cwds.cms.data.access.service.DataAccessServiceBase;
 import gov.ca.cwds.cms.data.access.service.DataAccessServicesException;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DefaultDataAccessLifeCycle;
-import gov.ca.cwds.data.legacy.cms.dao.StaffPersonDao;
 import gov.ca.cwds.data.legacy.cms.entity.StaffPerson;
+import java.io.Serializable;
 
 /** @author CWDS CALS API Team */
 public class StaffPersonService

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/SubstituteCareProviderCoreService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/SubstituteCareProviderCoreService.java
@@ -21,7 +21,6 @@ import gov.ca.cwds.cms.data.access.dto.ExtendedSCPEntityAwareDTO;
 import gov.ca.cwds.cms.data.access.dto.SCPEntityAwareDTO;
 import gov.ca.cwds.cms.data.access.mapper.CountyOwnershipMapper;
 import gov.ca.cwds.cms.data.access.service.BusinessValidationService;
-import gov.ca.cwds.cms.data.access.service.DataAccessServiceBase;
 import gov.ca.cwds.cms.data.access.service.DataAccessServicesException;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessBundle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/SubstituteCareProviderCoreService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/SubstituteCareProviderCoreService.java
@@ -69,9 +69,9 @@ public class SubstituteCareProviderCoreService
   @Override
   public SubstituteCareProvider create(
       @Authorize("substituteCareProvider:create:scpEntityAwareDTO.entity")
-          SCPEntityAwareDTO entityAwareDTO)
+          SCPEntityAwareDTO entityAwareDto)
       throws DataAccessServicesException {
-    return super.create(entityAwareDTO);
+    return super.create(entityAwareDto);
   }
 
   @Override

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/clientrelationship/ClientRelationshipCoreService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/clientrelationship/ClientRelationshipCoreService.java
@@ -1,16 +1,12 @@
 package gov.ca.cwds.cms.data.access.service.impl.clientrelationship;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 import com.google.inject.Inject;
-
 import gov.ca.cwds.cms.data.access.dto.ClientRelationshipAwareDTO;
 import gov.ca.cwds.cms.data.access.dto.ClientRelationshipDTO;
 import gov.ca.cwds.cms.data.access.mapper.ClientMapper;
 import gov.ca.cwds.cms.data.access.service.ClientRelationshipService;
-import gov.ca.cwds.cms.data.access.service.DataAccessServiceBase;
 import gov.ca.cwds.cms.data.access.service.DataAccessServicesException;
+import gov.ca.cwds.cms.data.access.service.impl.DataAccessServiceBase;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DefaultDataAccessLifeCycle;
 import gov.ca.cwds.data.legacy.cms.dao.ClientRelationshipDao;
@@ -19,6 +15,8 @@ import gov.ca.cwds.data.legacy.cms.entity.ClientRelationship;
 import gov.ca.cwds.data.legacy.cms.entity.syscodes.ClientRelationshipType;
 import gov.ca.cwds.data.persistence.cms.CmsKeyIdGenerator;
 import gov.ca.cwds.security.utils.PrincipalUtils;
+import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * Service for create/update/find ClientRelationship with business validation and data processing.
@@ -122,15 +120,15 @@ public class ClientRelationshipCoreService extends
     clientRelationship.setStartDate(clientRelationshipDto.getStartDate());
 
     // DRS: HOT-2176: isolate "possible non-threadsafe access to session".
-    crudDao.getSessionFactory().getCurrentSession().flush();
+    getCrudDao(true).getSessionFactory().getCurrentSession().flush();
     final Client legacyPrimaryClient =
         clientMapper.toLegacyClient(clientRelationshipDto.getSecondaryClient());
     final Client legacySecondaryClient =
         clientMapper.toLegacyClient(clientRelationshipDto.getPrimaryClient());
 
-    clientRelationship.setSecondaryClient(crudDao.getSessionFactory().getCurrentSession()
+    clientRelationship.setSecondaryClient(getCrudDao(true).getSessionFactory().getCurrentSession()
         .load(Client.class, legacySecondaryClient.getIdentifier()));
-    clientRelationship.setPrimaryClient(crudDao.getSessionFactory().getCurrentSession()
+    clientRelationship.setPrimaryClient(getCrudDao(true).getSessionFactory().getCurrentSession()
         .load(Client.class, legacyPrimaryClient.getIdentifier()));
 
     final ClientRelationshipAwareDTO awareDto = new ClientRelationshipAwareDTO();

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/tribalmembership/TribalMembershipVerificationCoreService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/tribalmembership/TribalMembershipVerificationCoreService.java
@@ -3,8 +3,8 @@ package gov.ca.cwds.cms.data.access.service.impl.tribalmembership;
 import static gov.ca.cwds.cms.data.access.Constants.Authorize.CLIENT_READ_CLIENT_ID;
 
 import gov.ca.cwds.cms.data.access.dto.TribalMembershipVerificationAwareDto;
-import gov.ca.cwds.cms.data.access.service.DataAccessServiceBase;
 import gov.ca.cwds.cms.data.access.service.DataAccessServicesException;
+import gov.ca.cwds.cms.data.access.service.impl.DataAccessServiceBase;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
 import gov.ca.cwds.cms.data.access.service.lifecycle.DefaultDataAccessLifeCycle;
 import gov.ca.cwds.data.legacy.cms.dao.TribalMembershipVerificationDao;
@@ -58,9 +58,10 @@ public class TribalMembershipVerificationCoreService
     return super.update(entityAwareDTO);
   }
 
+
   public List<TribalMembershipVerification> getByClientId(
       @Authorize(CLIENT_READ_CLIENT_ID) final String clientId) {
-    return crudDao.findByClientId(clientId);
+    return getCrudDao(true).findByClientId(clientId);
   }
 
   @Override

--- a/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/tribalmembership/TribalMembershipVerificationCoreService.java
+++ b/legacy-data-access-services/src/main/java/gov/ca/cwds/cms/data/access/service/impl/tribalmembership/TribalMembershipVerificationCoreService.java
@@ -40,22 +40,22 @@ public class TribalMembershipVerificationCoreService
   }
 
   @Override
-  public TribalMembershipVerification create(TribalMembershipVerificationAwareDto entityAwareDTO)
+  public TribalMembershipVerification create(TribalMembershipVerificationAwareDto entityAwareDto)
       throws DataAccessServicesException {
     String staffPerson = PrincipalUtils.getStaffPersonId();
-    entityAwareDTO.getEntity().setLastUpdateTime(LocalDateTime.now());
-    entityAwareDTO.getEntity().setLastUpdateId(staffPerson);
-    entityAwareDTO.getEntity().setThirdId(CmsKeyIdGenerator.getNextValue(staffPerson));
-    return super.create(entityAwareDTO);
+    entityAwareDto.getEntity().setLastUpdateTime(LocalDateTime.now());
+    entityAwareDto.getEntity().setLastUpdateId(staffPerson);
+    entityAwareDto.getEntity().setThirdId(CmsKeyIdGenerator.getNextValue(staffPerson));
+    return super.create(entityAwareDto);
   }
 
   @Override
-  public TribalMembershipVerification update(TribalMembershipVerificationAwareDto entityAwareDTO)
+  public TribalMembershipVerification update(TribalMembershipVerificationAwareDto entityAwareDto)
       throws DataAccessServicesException {
     String staffPerson = PrincipalUtils.getStaffPersonId();
-    entityAwareDTO.getEntity().setLastUpdateTime(LocalDateTime.now());
-    entityAwareDTO.getEntity().setLastUpdateId(staffPerson);
-    return super.update(entityAwareDTO);
+    entityAwareDto.getEntity().setLastUpdateTime(LocalDateTime.now());
+    entityAwareDto.getEntity().setLastUpdateId(staffPerson);
+    return super.update(entityAwareDto);
   }
 
 

--- a/legacy-data-access-services/src/test/java/gov/ca/cwds/cms/data/access/service/impl/PlacementHomeCoreServiceTest.java
+++ b/legacy-data-access-services/src/test/java/gov/ca/cwds/cms/data/access/service/impl/PlacementHomeCoreServiceTest.java
@@ -10,9 +10,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import gov.ca.cwds.cms.data.access.dao.PlacementHomeDao;
+import gov.ca.cwds.cms.data.access.dao.nonxa.NonXaPlacementHomeDao;
+import gov.ca.cwds.cms.data.access.dto.PlacementHomeEntityAwareDTO;
+import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
+import gov.ca.cwds.data.legacy.cms.entity.PlacementHome;
+import gov.ca.cwds.drools.DroolsException;
+import gov.ca.cwds.security.utils.PrincipalUtils;
 import java.io.Serializable;
 import java.util.function.Function;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,13 +26,6 @@ import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import gov.ca.cwds.cms.data.access.dao.PlacementHomeDao;
-import gov.ca.cwds.cms.data.access.dto.PlacementHomeEntityAwareDTO;
-import gov.ca.cwds.cms.data.access.service.lifecycle.DataAccessServiceLifecycle;
-import gov.ca.cwds.data.legacy.cms.entity.PlacementHome;
-import gov.ca.cwds.drools.DroolsException;
-import gov.ca.cwds.security.utils.PrincipalUtils;
 
 /** @author CWDS TPT-3 Team */
 @RunWith(PowerMockRunner.class)
@@ -40,6 +39,9 @@ public class PlacementHomeCoreServiceTest
 
   @Mock
   private PlacementHomeDao placementHomeDao;
+
+  @Mock
+  private NonXaPlacementHomeDao nonXaPlacementHomeDao;
 
   private PlacementHomeCoreService target;
 
@@ -62,14 +64,15 @@ public class PlacementHomeCoreServiceTest
     when(PrincipalUtils.getStaffPersonId()).thenReturn(USER_ID);
     when(placementHomeDao.create(any(PlacementHome.class)))
         .thenReturn(function.apply(PLACEMENT_ID));
-    target = PowerMockito.spy(new PlacementHomeCoreService(placementHomeDao));
+    target = PowerMockito.spy(new PlacementHomeCoreService(placementHomeDao,
+      nonXaPlacementHomeDao));
     when(target.getCreateLifeCycle()).thenReturn(null);
   }
 
   @Test
   public void create() throws Exception {
     final PlacementHome placementHome =
-        target.create(placementFunction.apply(function.apply(PLACEMENT_ID)));
+      target.create(placementFunction.apply(function.apply(PLACEMENT_ID)), true);
     assertNotNull(placementHome);
     assertEquals(PLACEMENT_ID, placementHome.getIdentifier());
   }

--- a/legacy-data-access-services/src/test/java/gov/ca/cwds/cms/data/access/service/impl/placementHome/BaseDocToolRulesPlacementHomeTest.java
+++ b/legacy-data-access-services/src/test/java/gov/ca/cwds/cms/data/access/service/impl/placementHome/BaseDocToolRulesPlacementHomeTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.fail;
 
 import gov.ca.cwds.cms.data.access.Constants.StaffPersonPrivileges;
 import gov.ca.cwds.cms.data.access.dao.PlacementHomeDao;
+import gov.ca.cwds.cms.data.access.dao.nonxa.NonXaPlacementHomeDao;
 import gov.ca.cwds.cms.data.access.dto.PlacementHomeEntityAwareDTO;
 import gov.ca.cwds.cms.data.access.service.BusinessValidationService;
 import gov.ca.cwds.cms.data.access.service.impl.BaseDocToolRulesTest;
@@ -21,13 +22,19 @@ public abstract class BaseDocToolRulesPlacementHomeTest extends BaseDocToolRules
   protected PlacementHomeCoreService placementHomeService;
   protected BusinessValidationService businessValidationService;
   protected PlacementHomeEntityAwareDTO placementHomeEntityAwareDTO;
+
   @Mock
   protected PlacementHomeDao placementHomeDao;
+
+  @Mock
+  protected NonXaPlacementHomeDao nonXaPlacementHomeDao;
+
 
   @Before
   public void setUp() {
     businessValidationService = new BusinessValidationService(droolsService);
-    placementHomeService = new PlacementHomeCoreService(placementHomeDao);
+    placementHomeService = new PlacementHomeCoreService(placementHomeDao,
+      nonXaPlacementHomeDao);
     placementHomeEntityAwareDTO = prepareSuccessfulPlacementHomeEntityAwareDTO();
   }
 


### PR DESCRIPTION
### JIRA Issue Link
https://osi-cwds.atlassian.net/browse/SEAR-475

### Technical Description
Introduced approach how to utilize XA or non-XA session factories in legacy data access services depending on what developer needs. Currently solution covers predominantly cals-api project needs (PlacementHomeCoreService) but, if needed, may be expanded to all other legacy data services. Backward compatibility is intact. If client application injects only one session factory library works as prior to change

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 

### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Technical debt
XA methods were added to Legacy access services' interface. But feature currently works only for Placement Home service. If needed, rest of services have to be upgraded
